### PR TITLE
追記させていただきました。

### DIFF
--- a/Sketch/Classes/SketchView.swift
+++ b/Sketch/Classes/SketchView.swift
@@ -147,6 +147,10 @@ public class SketchView: UIView {
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first else { return }
 
+        if currentTool != nil {
+            finishDrawing()
+        }
+
         previousPoint1 = touch.previousLocation(in: self)
         currentPoint = touch.location(in: self)
         currentTool = toolWithCurrentSettings()

--- a/Sketch/Classes/SketchView.swift
+++ b/Sketch/Classes/SketchView.swift
@@ -158,6 +158,8 @@ public class SketchView: UIView {
         currentTool?.lineColor = lineColor
         currentTool?.lineAlpha = lineAlpha
 
+        sketchViewDelegate?.drawView?(self, willBeginDrawUsingTool: currentTool! as AnyObject)
+        
         switch currentTool! {
         case is PenTool:
             guard let penTool = currentTool as? PenTool else { return }


### PR DESCRIPTION
鈴木光成と申します。

お絵かきツールを使わせていただこうと思い、実装していたところ、以下２点気になりましたので、コードを追記いたしました。

以下手順の際、描画した線が意図せず部分的に消えてしまいます。
１，SketchViewをUIScrollView内に配置
２，線を描き、そのまま指を離さず２本目で拡大操作を始める
３，拡大操作終了
４，２で描いた線の近くに別の線を描くと、部分的に消える
（ストア版Doodle Maker では、同操作にてUndoが実行されているように見えます）
このため、条件によりfinishDrawing()を呼び出すよう追記いたしました。
ーーーーーーーーーーーーーーーーーー
線など描き始める際、willBeginDrawUsingTool が届かなかったため、追記いたしました。

以上になります。
よろしくお願いいたします。