### PR TITLE
Update SketchTool.swift

### DIFF
--- a/Sketch/Classes/SketchTool.swift
+++ b/Sketch/Classes/SketchTool.swift
@@ -71,7 +71,7 @@ class PenTool: UIBezierPath, SketchTool {
     
     func draw() {
         guard let ctx = UIGraphicsGetCurrentContext() else { return }
-        
+        ctx.setShouldAntialias(false)
         switch drawingPenType {
         case .normal:
             ctx.addPath(path)
@@ -107,7 +107,7 @@ class PenTool: UIBezierPath, SketchTool {
 class EraserTool: PenTool {
     override func draw() {
         guard let ctx = UIGraphicsGetCurrentContext() else { return }
-        
+        ctx.setShouldAntialias(false)
         ctx.saveGState()
         ctx.addPath(path)
         ctx.setLineCap(.round)


### PR DESCRIPTION
Fix that there will be some pixels with half-transparent which can't be filled when we use FillTool to flood fill some enclosed area.